### PR TITLE
Removing the autofocus attribute from input field

### DIFF
--- a/includes/stripe-display.php
+++ b/includes/stripe-display.php
@@ -47,7 +47,7 @@ function wp_stripe_form() {
         <div class="wp-stripe-notification wp-stripe-failure payment-errors" style="display:none"></div>
 
         <div class="stripe-row">
-                <input type="text" name="wp_stripe_name" class="wp-stripe-name" placeholder="<?php _e('Name', 'wp-stripe'); ?> *" value="<?php echo $name; ?>" autofocus required />
+                <input type="text" name="wp_stripe_name" class="wp-stripe-name" placeholder="<?php _e('Name', 'wp-stripe'); ?> *" value="<?php echo $name; ?>" required />
         </div>
 
         <div class="stripe-row">


### PR DESCRIPTION
The name input field autofocus was causing the page to scroll down to that field.